### PR TITLE
fix: eliminate $() prompts in draft-email

### DIFF
--- a/commands/draft-email.md
+++ b/commands/draft-email.md
@@ -8,38 +8,22 @@ Workflow:
    - A single newline between lines is a *soft break* (rendered as a space, not a line break). To force a hard line break, use `<br/>` at the break point.
    - Sign-offs like "Best regards," followed by a name on the next line must use `<br/>`: `Best regards,<br/>--Terry`. Without it, CommonMark will collapse them onto one line.
 3. Show the user the draft body and the To/Cc/Bcc/Subject fields for review before opening Outlook.
-4. Once approved, write the Markdown body to a temp file and invoke the script in a single Bash command. The snippet below handles both WSL and Git Bash (MINGW) environments:
+4. Once approved, use the Write tool to save the Markdown body to `/tmp/email-body.md`, then invoke the wrapper script. The script handles WSL/MINGW path conversion internally:
    ```
-   # Determine paths -- WSL needs wslpath conversion for powershell.exe
-   if [ -n "$WSL_DISTRO_NAME" ]; then
-     WINTMP=$(wslpath "$(cmd.exe /C 'echo %TEMP%' 2>/dev/null | tr -d '\r')")
-     TMPFILE="$WINTMP/email-body.md"
-     SCRIPT_PATH=$(wslpath -w "$HOME/.claude/scripts/New-OutlookDraft.ps1")
-     BODY_PATH=$(wslpath -w "$TMPFILE")
-   else
-     TMPFILE="$TEMP/email-body.md"
-     SCRIPT_PATH="$HOME/.claude/scripts/New-OutlookDraft.ps1"
-     BODY_PATH="$TMPFILE"
-   fi
-
-   cat > "$TMPFILE" <<'EMAILEOF'
-   <markdown body here>
-   EMAILEOF
-   powershell.exe -ExecutionPolicy Bypass -File "$SCRIPT_PATH" \
-     -To "<to>" -Cc "<cc>" -Bcc "<bcc>" -Subject "<subject>" \
-     -BodyFile "$BODY_PATH"
-   rm -f "$TMPFILE"
+   ~/.claude/scripts/send-outlook-draft.sh \
+     --to "<to>" --cc "<cc>" --bcc "<bcc>" --subject "<subject>" \
+     --body-file /tmp/email-body.md
    ```
-   Omit -Cc/-Bcc flags if not specified.
+   Omit --cc/--bcc flags if not specified. The script copies the body to a Windows-accessible temp location and cleans up automatically.
 5. **Reply mode:** If the user says "reply to" or "respond to" an existing email thread, you need the Outlook EntryID of the original message. To get it, run:
    ```
    powershell.exe -Command "(New-Object -ComObject Outlook.Application).ActiveExplorer().Selection.Item(1).EntryID"
    ```
-   This returns the EntryID of the currently selected message in Outlook. Then use `-EntryID` instead of `-To` and `-Subject` (omit both -- recipients and subject come from the original). Add `-ReplyAll` to reply to all recipients. You can still override `-Cc` or `-Bcc`. Example:
+   This returns the EntryID of the currently selected message in Outlook. Then use `--entry-id` instead of `--to` and `--subject` (omit both -- recipients and subject come from the original). Add `--reply-all` to reply to all recipients. You can still override `--cc` or `--bcc`. Example:
    ```
-   powershell.exe -ExecutionPolicy Bypass -File "$SCRIPT_PATH" \
-     -EntryID "<entry-id>" -ReplyAll \
-     -BodyFile "$BODY_PATH"
+   ~/.claude/scripts/send-outlook-draft.sh \
+     --entry-id "<entry-id>" --reply-all \
+     --body-file /tmp/email-body.md
    ```
 
 If the user provides the body content directly, use it as-is. If they describe what the email should say, compose appropriate text.

--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,10 @@ install_file() {
     fi
 
     transform_file "$src" > "$dest"
+    # Shell scripts need execute permission
+    case "$name" in
+        *.sh) chmod +x "$dest" ;;
+    esac
     echo "  OK   $name"
 }
 

--- a/scripts/send-outlook-draft.sh
+++ b/scripts/send-outlook-draft.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# ORIGINAL SOURCE -- install to ~/.claude/scripts/ using install.sh
+#
+# send-outlook-draft.sh -- wrapper that resolves WSL/MINGW paths and
+# invokes New-OutlookDraft.ps1 via powershell.exe.
+#
+# Copyright (c) 2026 MCCI Corporation. MIT license.
+#
+# Usage:
+#   send-outlook-draft.sh --to "a@b.com" --subject "Hi" --body-file /tmp/body.md
+#   send-outlook-draft.sh --entry-id "0000..." --reply-all --body-file /tmp/body.md
+
+set -euo pipefail
+
+# --- Parse arguments ---
+TO=""
+CC=""
+BCC=""
+SUBJECT=""
+BODY_FILE=""
+ENTRY_ID=""
+REPLY_ALL=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --to)        TO="$2";        shift 2 ;;
+        --cc)        CC="$2";        shift 2 ;;
+        --bcc)       BCC="$2";       shift 2 ;;
+        --subject)   SUBJECT="$2";   shift 2 ;;
+        --body-file) BODY_FILE="$2"; shift 2 ;;
+        --entry-id)  ENTRY_ID="$2";  shift 2 ;;
+        --reply-all) REPLY_ALL=1;    shift   ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$BODY_FILE" ]; then
+    echo "Error: --body-file is required." >&2
+    exit 1
+fi
+
+if [ ! -f "$BODY_FILE" ]; then
+    echo "Error: body file not found: $BODY_FILE" >&2
+    exit 1
+fi
+
+# --- Resolve paths for the current environment ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PS1_NAME="New-OutlookDraft.ps1"
+
+CLEANUP_BODY=""
+
+if [ -n "${WSL_DISTRO_NAME:-}" ]; then
+    # WSL: convert to Windows paths for powershell.exe
+    SCRIPT_PATH="$(wslpath -w "$SCRIPT_DIR/$PS1_NAME")"
+
+    # Body file must be on a Windows-native filesystem for uv/PowerShell.
+    # If it's under a Linux-only path (e.g. /tmp/), copy to Windows %TEMP%.
+    WINTMP="$(wslpath "$(cmd.exe /C 'echo %TEMP%' 2>/dev/null | tr -d '\r')")"
+    WIN_BODY="$WINTMP/claude-email-body-$$.md"
+    cp "$BODY_FILE" "$WIN_BODY"
+    CLEANUP_BODY="$WIN_BODY"
+    BODY_PATH="$(wslpath -w "$WIN_BODY")"
+elif [ "${OSTYPE:-}" = "msys" ] || [ "${MSYSTEM:-}" != "" ]; then
+    # Git Bash / MINGW: paths work as-is for powershell.exe
+    SCRIPT_PATH="$SCRIPT_DIR/$PS1_NAME"
+    BODY_PATH="$BODY_FILE"
+else
+    echo "Error: this script requires WSL or Git Bash (MINGW) on Windows." >&2
+    exit 1
+fi
+
+cleanup() {
+    [ -n "$CLEANUP_BODY" ] && rm -f "$CLEANUP_BODY"
+}
+trap cleanup EXIT
+
+# --- Build the powershell.exe command ---
+PS_ARGS=(-ExecutionPolicy Bypass -File "$SCRIPT_PATH")
+
+if [ -n "$ENTRY_ID" ]; then
+    PS_ARGS+=(-EntryID "$ENTRY_ID")
+    if [ "$REPLY_ALL" -eq 1 ]; then
+        PS_ARGS+=(-ReplyAll)
+    fi
+else
+    if [ -n "$TO" ]; then
+        PS_ARGS+=(-To "$TO")
+    fi
+    if [ -n "$SUBJECT" ]; then
+        PS_ARGS+=(-Subject "$SUBJECT")
+    fi
+fi
+
+if [ -n "$CC" ]; then
+    PS_ARGS+=(-Cc "$CC")
+fi
+if [ -n "$BCC" ]; then
+    PS_ARGS+=(-Bcc "$BCC")
+fi
+
+PS_ARGS+=(-BodyFile "$BODY_PATH")
+
+# --- Invoke ---
+exec powershell.exe "${PS_ARGS[@]}"


### PR DESCRIPTION
## Summary
- Added `scripts/send-outlook-draft.sh` wrapper that handles WSL/MINGW path resolution internally
- Simplified `commands/draft-email.md` template so generated bash commands contain no `$()` substitutions
- Updated `install.sh` to `chmod +x` installed `.sh` files

Fixes #19

## Test plan
- [ ] Run `./install.sh -f` to install updated files to `~/.claude/`
- [ ] Verify `~/.claude/scripts/send-outlook-draft.sh` is executable
- [ ] Test `/draft-email` in Claude Code -- no "$() command substitution" prompt should appear
- [ ] Test new-email mode (--to, --subject, --body-file)
- [ ] Test reply mode (--entry-id, --reply-all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)