### PR TITLE
fix: preserve shebang on line 1 in installed scripts (fixes #21)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,11 +25,22 @@ for arg in "$@"; do
 done
 
 # Build the installed content from a repo source file (to stdout).
+# If the file starts with a shebang (#!), preserve it on line 1 so the
+# kernel can find it; place the provenance header on lines 2-3 instead.
 transform_file() {
     local src="$1"
-    printf '# INSTALLED FROM mcci-claude-tools -- do not edit this copy.\n'
-    printf '# Original: %s\n' "$src"
-    grep -v '^# ORIGINAL SOURCE --' "$src"
+    local first_line
+    first_line=$(head -1 "$src")
+    if [[ "$first_line" == '#!'* ]]; then
+        printf '%s\n' "$first_line"
+        printf '# INSTALLED FROM mcci-claude-tools -- do not edit this copy.\n'
+        printf '# Original: %s\n' "$src"
+        tail -n +2 "$src" | grep -v '^# ORIGINAL SOURCE --'
+    else
+        printf '# INSTALLED FROM mcci-claude-tools -- do not edit this copy.\n'
+        printf '# Original: %s\n' "$src"
+        grep -v '^# ORIGINAL SOURCE --' "$src"
+    fi
 }
 
 install_file() {


### PR DESCRIPTION
## Summary
- `transform_file()` now detects a `#!` shebang on line 1 and emits it before the provenance header, so installed `.sh` files can be executed directly (e.g., from Python `subprocess.run()`)
- Non-shebang files (`.ps1`, `.py`, `.md`) are unchanged: provenance header still goes on line 1

## Test plan
- [x] `./install.sh -f` succeeds
- [x] `head -1 ~/.claude/scripts/send-outlook-draft.sh` shows `#!/bin/bash`
- [x] `./install.sh --check` reports all files OK
- [ ] `~/.claude/scripts/send-outlook-draft.sh --help` executes without "Exec format error"

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)