### PR TITLE
Fix OL spacing in Outlook with mso-margin-bottom-alt

### DIFF
--- a/scripts/md-to-email-html.py
+++ b/scripts/md-to-email-html.py
@@ -185,6 +185,9 @@ def _fix_for_outlook(html: str) -> str:
     # --- Fix last <li> margin in each list ---
     # Outlook ignores <ul>/<ol> container margins and only uses <li>
     # margins.  Set the last <li>'s margin-bottom to match <p> spacing.
+    # Use both standard margin-bottom AND mso-margin-bottom-alt for
+    # Outlook/Word compatibility (Word's engine reads the mso- property
+    # for <ol> lists even when it ignores standard margin-bottom).
     for list_tag in tree.iter("ol", "ul"):
         li_items = [child for child in list_tag if child.tag == "li"]
         if not li_items:
@@ -208,6 +211,9 @@ def _fix_for_outlook(html: str) -> str:
             )
         else:
             style = style.rstrip("; ") + f"; margin-bottom:{PARAGRAPH_MARGIN_BOTTOM};"
+        # Add MSO-specific margin property for Outlook/Word engine
+        if "mso-margin-bottom-alt" not in style:
+            style = style.rstrip("; ") + f"; mso-margin-bottom-alt:{PARAGRAPH_MARGIN_BOTTOM};"
         last_li.set("style", style)
 
     # --- Handle <pre> inside list items ---


### PR DESCRIPTION
Fixes #28

The #25 fix correctly sets `margin-bottom:10px` on the last `<li>`, but Outlook/Word ignores standard `margin-bottom` on `<li>` inside `<ol>` tags (it works for `<ul>`). 

Adds `mso-margin-bottom-alt:10px` as a parallel property that Word's HTML engine reads. Verified in Outlook: spacing after numbered lists now matches spacing before them and matches bullet list behavior.