### PR TITLE
Add Find-OutlookByMessageId.ps1 + find-outlook-by-msgid.sh (#32)

### DIFF
--- a/scripts/Find-OutlookByMessageId.ps1
+++ b/scripts/Find-OutlookByMessageId.ps1
@@ -1,0 +1,118 @@
+<#
+.SYNOPSIS
+    Find an Outlook message by Internet Message-Id and emit its EntryID
+    plus identifying fields (subject, sender, received time, folder).
+
+.DESCRIPTION
+    Searches the user's MAPI mailbox for a message whose
+    PR_INTERNET_MESSAGE_ID_W (proptag 0x1035001F) matches the supplied
+    Message-Id. By default searches Inbox first, then Sent Items, and
+    returns the first match.
+
+    Output is one key=value line per field, lowercase keys:
+        folder=Inbox
+        subject=RE: ...
+        from=sender@example.com
+        received=05/05/2026 06:38:53
+        entry_id=000000008253A9...
+
+    Exit 0 on match, exit 1 on not-found, exit 2 on error.
+
+    The Message-Id is matched verbatim, so the angle brackets matter --
+    PR_INTERNET_MESSAGE_ID stores the value WITH the surrounding < >.
+    If the caller supplies a bare id (no brackets), this script wraps
+    it before searching. Trailing CR/LF and surrounding whitespace are
+    trimmed.
+
+.PARAMETER MessageId
+    The RFC 5322 Message-Id of the email to find. Brackets optional.
+    Examples (all equivalent):
+        abc123@example.com
+        <abc123@example.com>
+
+.PARAMETER Folders
+    Comma-separated MAPI default-folder ids to search, in order.
+    Defaults to "6,5" (Inbox, Sent Items). Other useful values:
+        4   Outbox
+        9   Calendar
+        10  Contacts
+        16  Drafts
+
+.PARAMETER All
+    Continue searching after the first match and emit every match.
+    Without -All, the script stops at the first match.
+
+.EXAMPLE
+    Find-OutlookByMessageId.ps1 -MessageId '<abc@example.com>'
+
+.EXAMPLE
+    Find-OutlookByMessageId.ps1 -MessageId 'abc@example.com' -Folders '6,5,16'
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$MessageId,
+
+    [string]$Folders = "6,5",
+
+    [switch]$All
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+# Normalize the Message-Id: trim whitespace, ensure angle brackets.
+$mid = $MessageId.Trim()
+if (-not $mid.StartsWith('<')) { $mid = '<' + $mid }
+if (-not $mid.EndsWith('>'))   { $mid = $mid + '>' }
+
+# Build the DASL filter. PR_INTERNET_MESSAGE_ID_W = 0x1035001F.
+# Single quotes inside the filter value must be doubled.
+$escaped = $mid.Replace("'", "''")
+$filter = '@SQL="http://schemas.microsoft.com/mapi/proptag/0x1035001F" = ''' + $escaped + ''''
+
+try {
+    $ol = New-Object -ComObject Outlook.Application
+} catch {
+    Write-Error "Could not connect to Outlook. Is Outlook running?"
+    exit 2
+}
+
+$ns = $ol.Session
+$folderIds = $Folders.Split(',') | ForEach-Object { [int]$_.Trim() }
+
+$anyFound = $false
+
+try {
+    foreach ($fid in $folderIds) {
+        try {
+            $folder = $ns.GetDefaultFolder($fid)
+        } catch {
+            Write-Warning "Could not open default folder id $fid : $_"
+            continue
+        }
+
+        $items = $folder.Items
+        $found = $items.Find($filter)
+        while ($found) {
+            $anyFound = $true
+            Write-Output ("folder=" + $folder.Name)
+            Write-Output ("subject=" + $found.Subject)
+            Write-Output ("from=" + $found.SenderEmailAddress)
+            Write-Output ("received=" + $found.ReceivedTime)
+            Write-Output ("entry_id=" + $found.EntryID)
+            if (-not $All) { exit 0 }
+            Write-Output "---"
+            $found = $items.FindNext()
+        }
+    }
+} finally {
+    if ($ns)  { [System.Runtime.InteropServices.Marshal]::ReleaseComObject($ns)  | Out-Null }
+    [System.Runtime.InteropServices.Marshal]::ReleaseComObject($ol) | Out-Null
+}
+
+if ($anyFound) { exit 0 }
+
+Write-Output ("not_found=" + $mid)
+exit 1

--- a/scripts/find-outlook-by-msgid.sh
+++ b/scripts/find-outlook-by-msgid.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# find-outlook-by-msgid.sh -- look up an Outlook message by Internet Message-Id
+# and print key=value lines (folder, subject, from, received, entry_id).
+#
+# Copyright (c) 2026 MCCI Corporation. MIT license.
+#
+# Usage:
+#   find-outlook-by-msgid.sh <message-id>
+#   find-outlook-by-msgid.sh --folders 6,5,16 --all <message-id>
+#
+# The message-id may be passed with or without the surrounding angle
+# brackets; the script normalizes either form.
+#
+# Exit codes:
+#   0  match found (one or more lines printed)
+#   1  no match
+#   2  error (Outlook unavailable, etc.)
+
+set -euo pipefail
+
+FOLDERS=""
+ALL=0
+MID=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --folders) FOLDERS="$2"; shift 2 ;;
+        --all)     ALL=1;        shift   ;;
+        --help|-h)
+            sed -n '2,17p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        --*)
+            echo "Unknown option: $1" >&2
+            exit 2
+            ;;
+        *)
+            if [ -n "$MID" ]; then
+                echo "Error: multiple message-id arguments not supported." >&2
+                exit 2
+            fi
+            MID="$1"; shift ;;
+    esac
+done
+
+if [ -z "$MID" ]; then
+    echo "Error: message-id is required." >&2
+    echo "Usage: $(basename "$0") [--folders 6,5,16] [--all] <message-id>" >&2
+    exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PS1_NAME="Find-OutlookByMessageId.ps1"
+
+if [ -n "${WSL_DISTRO_NAME:-}" ]; then
+    SCRIPT_PATH="$(wslpath -w "$SCRIPT_DIR/$PS1_NAME")"
+elif [ "${OSTYPE:-}" = "msys" ] || [ "${MSYSTEM:-}" != "" ]; then
+    SCRIPT_PATH="$SCRIPT_DIR/$PS1_NAME"
+else
+    echo "Error: this script requires WSL or Git Bash (MINGW) on Windows." >&2
+    exit 2
+fi
+
+PS_ARGS=(-ExecutionPolicy Bypass -File "$SCRIPT_PATH" -MessageId "$MID")
+if [ -n "$FOLDERS" ]; then
+    PS_ARGS+=(-Folders "$FOLDERS")
+fi
+if [ "$ALL" -eq 1 ]; then
+    PS_ARGS+=(-All)
+fi
+
+# powershell.exe emits CRLF line endings; strip the CR for clean shell parsing.
+powershell.exe "${PS_ARGS[@]}" | tr -d '\r'
+exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Adds a scripted Outlook Message-Id → EntryID lookup so the `draft-email` reply flow can find the original message without the agent re-synthesizing the recipe each time.

Closes #32.

## What's added

- `scripts/Find-OutlookByMessageId.ps1` — searches MAPI folders by `PR_INTERNET_MESSAGE_ID_W` (proptag `0x1035001F`). Emits `key=value` lines: `folder`, `subject`, `from`, `received`, `entry_id`. Defaults to Inbox then Sent Items; `-Folders 6,5,16` configures. `-All` walks every match. Normalizes the angle-bracket form on the way in.
- `scripts/find-outlook-by-msgid.sh` — bash wrapper, WSL/MINGW path resolution, strips `\r` from output. Exit 0 / 1 / 2 = found / not-found / error.

## Test

Live test against today's Philips inbound:

```
$ ~/.claude/scripts/find-outlook-by-msgid.sh '<PAWP122MB0390C0E286F7D64D2F38D6FF983E2@PAWP122MB0390.EURP122.PROD.OUTLOOK.COM>'
folder=Inbox
subject=RE: MCCI & Philips MR - TrueTask USB Stack
from=DINESH.DANGE@philips.com
received=05/05/2026 06:38:53
entry_id=000000008253A9BFB4F21D4B8BBD161D208C8F5A64B99005
```

Returned EntryID is the same one the inline recipe found, in fewer keystrokes and without bash quoting hazards.

## Follow-up (separate, not in this PR)

The sales-pipeline `feedback_reply_threading.md` memory currently inlines a PowerShell one-liner for this lookup. Once this lands and propagates via `install.sh -f`, that memory should be updated to invoke `find-outlook-by-msgid.sh` instead.