### PR TITLE
parse-msg: survive a message attached to a message

### DIFF
--- a/scripts/parse-msg.py
+++ b/scripts/parse-msg.py
@@ -87,6 +87,41 @@ def split_thread(body):
     return first_offset, segments
 
 
+def attachment_size(data):
+    """Length of an attachment payload, in bytes.
+
+    A message attached to a message arrives as an extract_msg Message, not as
+    bytes, and has no len(). Its exported form gives a real size where the
+    installed extract_msg offers one; otherwise report 0 rather than raising,
+    because one such attachment used to abort a whole batch (#40).
+    """
+    if data is None:
+        return 0
+    if isinstance(data, (bytes, bytearray)):
+        return len(data)
+    export = getattr(data, "export", None)
+    if callable(export):
+        try:
+            blob = export()
+            if isinstance(blob, (bytes, bytearray)):
+                return len(blob)
+        except Exception:
+            pass
+    return 0
+
+
+def attachment_name(a):
+    """The attachment's filename, or one built from an attached message's
+    subject. Outlook sets neither filename property on an attached .msg."""
+    name = a.longFilename or a.shortFilename
+    if name:
+        return name
+    subject = getattr(getattr(a, "data", None), "subject", None)
+    if not subject:
+        return None
+    return re.sub(r'[\\/:*?"<>|]+', "_", subject).strip() + ".msg"
+
+
 def dump_msg(path):
     import hashlib
     msg = extract_msg.Message(str(path))
@@ -132,9 +167,10 @@ def dump_msg(path):
         "rtf_present": _safe(lambda: bool(msg.rtfBody)),
         "attachments": [
             {
-                "filename": a.longFilename or a.shortFilename,
-                "size": len(a.data) if a.data else 0,
+                "filename": attachment_name(a),
+                "size": attachment_size(a.data),
                 "mime": getattr(a, "mimetype", None),
+                "embedded": not isinstance(a.data, (bytes, bytearray)) and a.data is not None,
             }
             for a in msg.attachments
         ],


### PR DESCRIPTION
`len(a.data)` raised `TypeError: object of type 'Message' has no len()` when an attachment was itself a `.msg`, aborting the whole run. One file in a nineteen-file day stopped the batch.

- `attachment_size` handles bytes, an embedded `Message` with an exportable form, and anything else by returning 0 rather than raising.
- `attachment_name` falls back to the embedded message's sanitized subject plus `.msg`, since Outlook sets neither filename property on an attached message.
- Entries carry `embedded: true/false`.

Verified on the offending file: parses clean, three attached store notices come out named `A shipment from order #3747 is on the way.msg`, the two inline images unchanged.

Mining an attached `.msg` as a message in its own right is out of scope — `embedded_messages` still means the quoted-text chain. fixes #40